### PR TITLE
fix metaspace exitOnOom and new memory default setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ If you do not want this behavior then override the CMD directive
 
 You can set the following ENV vars to control the behavior
  - REMOTE_DEBUG: turn on remote debuging on DEBUG_PORT (default 5005)
- - JAVA_MAX_MEM_RATIO: adjust the ratio of memory set as XMX. Default 80%
+ - JAVA_MAX_MEM_RATIO: adjust the ratio of memory set as XMX. Default 25%
+ - JAVA_MAX_METASPACE_RATIO: adjust the ratio of memory set as MaxMetaspace. Default 15%
+ - DISABLE_EXIT_ON_OOM: set to anything to disable exit jvm if OOM
  - JAVA_DIAGNOSTICS: set this to turn on GC diagnostics
  - JAVA_CORE_LIMIT: Force the core limit to this value
+ - DISABLE_JOLOKIA: set to disable Jolokia agent
  
 When creating your `java` executable line in your start script make sure to include the `$JAVA_OPTS` ENV var
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,8 +53,8 @@ auroradocker {
   buildArgs = [
       jolokiaVersion: "1.3.7",
       javaMajorVersion: "8",
-      javaMinorVersion: "141",
-      javaBuildVersion: "15-r0",
+      javaMinorVersion: "144",
+      javaBuildVersion: "01-r0",
       baseImageVersion: version
   ]
 }
@@ -100,7 +100,8 @@ task testOutputImage() {
     if (result.process.exitValue() != 0) {
       throw new GradleException("Unable to run image. Inspect output for details.")
     }
-    assert result.output.contains("JAVA_OPTS=-Xmx410m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2")
+    assert result.output.contains("JAVA_OPTS=-Xmx358m -XX:MaxMetaspaceSize=77m -XX:+ExitOnOutOfMemoryError -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -javaagent:/opt/jolokia/jolokia-jvm-1.3.7-agent.jar=host=0.0.0.0,port=8778,protocol=https"
+    )
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ auroradocker {
       jolokiaVersion: "1.3.7",
       javaMajorVersion: "8",
       javaMinorVersion: "151",
-      javaBuildVersion: "12r0",
+      javaBuildVersion: "12-r0",
       baseImageVersion: version
   ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ auroradocker {
   buildArgs = [
       jolokiaVersion: "1.3.7",
       javaMajorVersion: "8",
-      javaMinorVersion: "144",
-      javaBuildVersion: "01-r0",
+      javaMinorVersion: "151",
+      javaBuildVersion: "12r0",
       baseImageVersion: version
   ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,40 +1,26 @@
-import java.text.SimpleDateFormat
-import java.util.Date
 import no.skatteetaten.aurora.gradle.plugins.docker.DockerTools
 import no.skatteetaten.aurora.gradle.plugins.docker.ProcessTools
-import java.io.*
 
 buildscript {
   repositories {
     mavenCentral()
     jcenter()
-    mavenLocal()
   }
   dependencies {
     classpath(
-        "no.skatteetaten.aurora.gradle.plugins:aurora-gradle-plugin:1.1.0",
-        "no.skatteetaten.aurora.gradle.plugins:aurora-docker-plugin:1.0.1",
+        "no.skatteetaten.aurora.gradle.plugins:aurora-gradle-plugin:1.2.1",
+        "no.skatteetaten.aurora.gradle.plugins:aurora-docker-plugin:1.1.0",
         "org.ajoberstar:grgit:1.1.0"
 
     )
   }
 }
 
-
-
-
 repositories {
   mavenCentral()
   jcenter()
   mavenLocal()
 }
-
-ext {
-  git = org.ajoberstar.grgit.Grgit.open(file('.'))
-
-  revision = git.head().id
-}
-
 
 ext.aurora = [
     requireStaging: false,

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ auroradocker {
       javaMajorVersion: "8",
       javaMinorVersion: "151",
       javaBuildVersion: "12-r0",
+
       baseImageVersion: version
   ]
 }
@@ -86,7 +87,7 @@ task testOutputImage() {
     if (result.process.exitValue() != 0) {
       throw new GradleException("Unable to run image. Inspect output for details.")
     }
-    assert result.output.contains("JAVA_OPTS=-Xmx358m -XX:MaxMetaspaceSize=77m -XX:+ExitOnOutOfMemoryError -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -javaagent:/opt/jolokia/jolokia-jvm-1.3.7-agent.jar=host=0.0.0.0,port=8778,protocol=https"
+    assert result.output.contains("JAVA_OPTS=-Xmx128m -XX:MaxMetaspaceSize=77m -XX:+ExitOnOutOfMemoryError -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -javaagent:/opt/jolokia/jolokia-jvm-1.3.7-agent.jar=host=0.0.0.0,port=8778,protocol=https"
     )
   }
 }

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+./gradlew testOutputImage
+
 ./gradlew pushImage -Dregistry=${REGISTRY}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Feb 24 09:58:42 CET 2017
+#Mon Oct 16 09:43:41 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip

--- a/src/main/docker/bin/java-options
+++ b/src/main/docker/bin/java-options
@@ -8,8 +8,9 @@
 # Env Vars evaluated:
 
 # JAVA_OPTIONS: Checked for already set options
+# JAVA_MAX_META_RATIO: Ratio used to calculcate max metaspace. Default 15 = 15% of maximum memory
 # JAVA_MAX_MEM_RATIO: Ratio use to calculate a default maximum Memory, in percent.
-#                     E.g. the default value "50" implies that 50% of the Memory
+#                     E.g. the default value "25" implies that 25% of the Memory
 #                     given to the container is used as the maximum heap memory with
 #                     '-Xmx'. It is a heuristic and should be better backed up with real
 #                     experiments and measurements.
@@ -40,8 +41,7 @@ max_metaspace() {
   # given (default is 15%)
   if [ "x$CONTAINER_MAX_MEMORY" != x ]; then
     local max_mem="${CONTAINER_MAX_MEMORY}"
-    local ratio=${JAVA_MAX_METASPACE_RATIO:-15}
-    local metaspaceRatio=${JAVA_MAX_META_RATIO:-15}
+    local metaspaceRatio=${JAVA_MAX_METASPACE_RATIO:-15}
     local metaspace=$(echo "${max_mem} ${metaspaceRatio} 1048576" | awk '{printf "%d\n" , ($1*$2)/(100*$3) + 0.5}')
    echo "-XX:MaxMetaspaceSize=${metaspace}m"
   fi
@@ -64,14 +64,14 @@ max_memory() {
   # given (default is 70%)
   if [ "x$CONTAINER_MAX_MEMORY" != x ]; then
     local max_mem="${CONTAINER_MAX_MEMORY}"
-    local ratio=${JAVA_MAX_MEM_RATIO:-70}
+    local ratio=${JAVA_MAX_MEM_RATIO:-25}
     local mx=$(echo "${max_mem} ${ratio} 1048576" | awk '{printf "%d\n" , ($1*$2)/(100*$3) + 0.5}')
 
     echo "-Xmx${mx}m"
   fi
 }
 exitoom() {
-  if [ "x$JAVA_EXIT_ON_OOM" == "x" ]; then
+  if [ "x$DISABLE_EXIT_ON_OOM" == "x" ]; then
    echo "-XX:+ExitOnOutOfMemoryError"
   fi
 }

--- a/src/main/docker/bin/java-options
+++ b/src/main/docker/bin/java-options
@@ -23,6 +23,29 @@
 # However, when your container gets killed because of an OOM, then you should tune
 # the absolute values
 #
+# Check for memory options and calculate a sane default if not given
+max_metaspace() {
+  # Check whether -Xmx is already given in JAVA_OPTIONS. Then we dont
+  # do anything here
+  if echo "${JAVA_OPTIONS}" | grep -q -- "-XX:MaxMetaspaceSize"; then
+    return
+  fi
+
+  # Check if explicitely disabled
+  if [ "x$JAVA_MAX_METASPACE_RATIO" = "x0" ]; then
+    return
+  fi
+
+  # Check for the 'real memory size' and caluclate mx from a ratio
+  # given (default is 80%)
+  if [ "x$CONTAINER_MAX_MEMORY" != x ]; then
+    local max_mem="${CONTAINER_MAX_MEMORY}"
+    local ratio=${JAVA_MAX_METASPACE_RATIO:-15}
+    local metaspaceRatio=${JAVA_MAX_META_RATIO:-15}
+    local metaspace=$(echo "${max_mem} ${metaspaceRatio} 1048576" | awk '{printf "%d\n" , ($1*$2)/(100*$3) + 0.5}')
+   echo "-XX:MaxMetaspaceSize=${metaspace}m"
+  fi
+}
 
 # Check for memory options and calculate a sane default if not given
 max_memory() {
@@ -41,13 +64,19 @@ max_memory() {
   # given (default is 80%)
   if [ "x$CONTAINER_MAX_MEMORY" != x ]; then
     local max_mem="${CONTAINER_MAX_MEMORY}"
-    local ratio=${JAVA_MAX_MEM_RATIO:-80}
+    local ratio=${JAVA_MAX_MEM_RATIO:-70}
     local mx=$(echo "${max_mem} ${ratio} 1048576" | awk '{printf "%d\n" , ($1*$2)/(100*$3) + 0.5}')
+
+    local metaspaceRatio=${JAVA_MAX_META_RATIO:-15}
+    local metaspace=$(echo "${max_mem} ${metaspaceRatio} 1048576" | awk '{printf "%d\n" , ($1*$2)/(100*$3) + 0.5}')
     echo "-Xmx${mx}m"
   fi
 }
-
-# Switch on diagnostics except when switched off
+exitoom() {
+  if [ "x$JAVA_EXIT_ON_OOM" == "x" ]; then
+   echo "-XX:+ExitOnOutOfMemoryError"
+  fi
+}
 diagnostics() {
   if [ "x$JAVA_DIAGNOSTICS" != "x" ]; then
     echo "-XX:NativeMemoryTracking=summary -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UnlockDiagnosticVMOptions"
@@ -85,4 +114,4 @@ debug_options() {
 
 
 # Echo options, trimming trailing and multiple spaces
-echo "$JAVA_OPTIONS $(max_memory) $(diagnostics) $(cpu_core_tunning) $(jolokia) $(debug_options)" | awk '$1=$1'
+echo "$JAVA_OPTIONS $(max_memory) $(max_metaspace) $(exitoom) $(diagnostics) $(cpu_core_tunning) $(jolokia) $(debug_options)" | awk '$1=$1'

--- a/src/main/docker/bin/java-options
+++ b/src/main/docker/bin/java-options
@@ -25,7 +25,7 @@
 #
 # Check for memory options and calculate a sane default if not given
 max_metaspace() {
-  # Check whether -Xmx is already given in JAVA_OPTIONS. Then we dont
+  # Check whether metaspace is already given in JAVA_OPTIONS. Then we dont
   # do anything here
   if echo "${JAVA_OPTIONS}" | grep -q -- "-XX:MaxMetaspaceSize"; then
     return
@@ -36,8 +36,8 @@ max_metaspace() {
     return
   fi
 
-  # Check for the 'real memory size' and caluclate mx from a ratio
-  # given (default is 80%)
+  # Check for the 'real memory size' and caluclate metaspace from a ratio
+  # given (default is 15%)
   if [ "x$CONTAINER_MAX_MEMORY" != x ]; then
     local max_mem="${CONTAINER_MAX_MEMORY}"
     local ratio=${JAVA_MAX_METASPACE_RATIO:-15}
@@ -61,14 +61,12 @@ max_memory() {
   fi
 
   # Check for the 'real memory size' and caluclate mx from a ratio
-  # given (default is 80%)
+  # given (default is 70%)
   if [ "x$CONTAINER_MAX_MEMORY" != x ]; then
     local max_mem="${CONTAINER_MAX_MEMORY}"
     local ratio=${JAVA_MAX_MEM_RATIO:-70}
     local mx=$(echo "${max_mem} ${ratio} 1048576" | awk '{printf "%d\n" , ($1*$2)/(100*$3) + 0.5}')
 
-    local metaspaceRatio=${JAVA_MAX_META_RATIO:-15}
-    local metaspace=$(echo "${max_mem} ${metaspaceRatio} 1048576" | awk '{printf "%d\n" , ($1*$2)/(100*$3) + 0.5}')
     echo "-Xmx${mx}m"
   fi
 }


### PR DESCRIPTION
Ny java version
- skrur på ExitOnMemory som vi pratet om på utviklermøte idag
- setter MaxMetaspaceSize til 15% av cgroup memory
- setter end max xmx til 70% fra 80%